### PR TITLE
Update github action

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "16"
           cache: "npm"


### PR DESCRIPTION
Hello 👋🏼 ,
The workflow is failing because of `setup-node@v2` getting deprecated...

For more context: https://github.com/actions/setup-node/issues/1275#issuecomment-2788204086

I didn't tested the commit 😱 